### PR TITLE
Correct timer weekday bitmask documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,18 +126,18 @@ Important behavior:
 
 Confirmed mapping:
 
-- Monday = `64`
-- Tuesday = `1`
-- Wednesday = `2`
-- Thursday = `4`
-- Friday = `8`
-- Saturday = `16`
-- Sunday = `32`
+- Monday = `1`
+- Tuesday = `2`
+- Wednesday = `4`
+- Thursday = `8`
+- Friday = `16`
+- Saturday = `32`
+- Sunday = `64`
 
 Examples:
 
-- `repeat=31` means Tuesday-Saturday (`1+2+4+8+16`)
-- `repeat=72` means Monday+Friday (`64+8`)
+- `repeat=31` means Monday-Friday (`1+2+4+8+16`)
+- `repeat=17` means Monday+Friday (`1+16`)
 
 ### Read timers
 

--- a/docs/save_timers_analysis.md
+++ b/docs/save_timers_analysis.md
@@ -118,18 +118,18 @@ Status:
 
 From a capture with seven one-day timers (one per weekday), the following mapping is confirmed:
 
-- `64` = Monday
-- `1` = Tuesday
-- `2` = Wednesday
-- `4` = Thursday
-- `8` = Friday
-- `16` = Saturday
-- `32` = Sunday
+- `1` = Monday
+- `2` = Tuesday
+- `4` = Wednesday
+- `8` = Thursday
+- `16` = Friday
+- `32` = Saturday
+- `64` = Sunday
 
 Examples:
 
-- `repeat: 72` (`64 + 8`) = Monday + Friday
-- `repeat: 31` (`1 + 2 + 4 + 8 + 16`) = Tuesday-Saturday
+- `repeat: 17` (`1 + 16`) = Monday + Friday
+- `repeat: 31` (`1 + 2 + 4 + 8 + 16`) = Monday-Friday
 
 ## Known uncertainties (not proven by these captures alone)
 

--- a/docs/timer_interpretation.md
+++ b/docs/timer_interpretation.md
@@ -22,7 +22,7 @@
 
 ## Repeat bitmask
 
-Fortolkning (foreslået ud fra observeret data):
+Fortolkning:
 
 - bit 0 = mandag
 - bit 1 = tirsdag


### PR DESCRIPTION
## Summary
- correct the documented weekday bitmask mapping for simple timers
- update README examples to match the verified mapping
- align the analysis and interpretation docs with the same weekday order

## Test strategy
- documentation-only change; verified by cross-checking the integration fix and observed app behavior

## Known limitations
- this PR updates documentation only; it does not change runtime code
- docs describe the currently verified mapping and may need revision if future API captures show different behavior

## Configuration changes
- none
